### PR TITLE
added a command to show how to start mysql if it is not running

### DIFF
--- a/en/developer.markdown
+++ b/en/developer.markdown
@@ -100,6 +100,10 @@ Remember to set the correct `mysql` password in the CloudStack properties file. 
 
     service mysqld status
 
+If it is not running you can start it start it with:
+
+    service mysqld start
+
 Install `git` to later clone the CloudStack source code:
 
     yum -y install git

--- a/en/developer.markdown
+++ b/en/developer.markdown
@@ -42,6 +42,10 @@ Remember to set the correct `mysql` password in the CloudStack properties file. 
 
     service mysql status
 
+If it is not running you can start mysql with:
+	
+    service mysql start
+
 Developers wanting to build CloudStack from source will want to install the following additional packages. If you dont' want to build from source just jump to the next section.
 
 Install `git` to later clone the CloudStack source code:


### PR DESCRIPTION
added a command to show how to start mysql in ubuntu if the service is not up. This is just to ensure that we are guiding the user through all steps and covering all angles.
